### PR TITLE
Changing getcwd() to base_path()

### DIFF
--- a/src/Http/Controllers/EnumController.php
+++ b/src/Http/Controllers/EnumController.php
@@ -36,7 +36,7 @@ class EnumController
                 ->reject(fn ($i) => $i->isDir() || str_ends_with($i->getRealPath(), '/..'))
                 ->map(function ($item) {
                     // Build the class name from the file path.
-                    $path = ucfirst(str_replace(getcwd() . '/', '', $item->getRealPath()));
+                    $path = ucfirst(str_replace(base_path() . '/', '', $item->getRealPath()));
                     return rtrim(str_replace(DIRECTORY_SEPARATOR, '\\', $path), '.php');
                 })
                 ->filter(function ($i) {

--- a/src/Http/Controllers/EnumController.php
+++ b/src/Http/Controllers/EnumController.php
@@ -36,7 +36,9 @@ class EnumController
                 ->reject(fn ($i) => $i->isDir() || str_ends_with($i->getRealPath(), '/..'))
                 ->map(function ($item) {
                     // Build the class name from the file path.
-                    $path = ucfirst(str_replace(base_path() . '/', '', $item->getRealPath()));
+                    $cwd = (app()->runningUnitTests()) ? getcwd() : base_path();
+
+                    $path = ucfirst(str_replace($cwd . '/', '', $item->getRealPath()));
                     return rtrim(str_replace(DIRECTORY_SEPARATOR, '\\', $path), '.php');
                 })
                 ->filter(function ($i) {


### PR DESCRIPTION
getcwd() doesn't work in live laravel applications because the code always runs from the public directory

base_path() and app_path() don't work in this testing situation because of orchestra testbench stuff

we'll just have to live with this hack