### PR TITLE
Fix token boundary issue

### DIFF
--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -176,7 +176,7 @@ JAVASCRIPT;
         // Filter out whitespace and comments from the tokens, as they are irrelevant.
         $tokens = array_filter(
             $tokens,
-            fn($token) => is_array($token) && $token[0] !== T_WHITESPACE && $token[0] !== T_COMMENT
+            fn ($token) => is_array($token) && $token[0] !== T_WHITESPACE && $token[0] !== T_COMMENT
         );
 
         // Reset array indexes after filtering.
@@ -199,6 +199,7 @@ JAVASCRIPT;
                 $class = $tokens[$index + 1][1];
             }
             if ($namespace && $class) {
+                // We've found both the namespace and the class, we can now stop reading and parsing the file.
                 break;
             }
         }

--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -171,46 +171,38 @@ JAVASCRIPT;
 
     protected function fqcnFromPath(string $path): string
     {
-        $namespace = $class = $buffer = '';
+        $tokens = token_get_all(file_get_contents($path));
 
-        $handle = fopen($path, 'r');
+        // Filter out whitespace and comments from the tokens, as they are irrelevant.
+        $tokens = array_filter(
+            $tokens,
+            fn($token) => is_array($token) && $token[0] !== T_WHITESPACE && $token[0] !== T_COMMENT
+        );
 
-        while (!feof($handle)) {
-            $buffer .= fread($handle, 512);
+        // Reset array indexes after filtering.
+        $tokens = array_values($tokens);
 
-            // Suppress warnings for cases where `$buffer` ends in the middle of a PHP comment.
-            $tokens = @token_get_all($buffer);
+        $namespace = $class = '';
 
-            // Filter out whitespace and comments from the tokens, as they are irrelevant.
-            $tokens = array_filter($tokens, fn($token) => $token[0] !== T_WHITESPACE && $token[0] !== T_COMMENT);
-
-            // Reset array indexes after filtering.
-            $tokens = array_values($tokens);
-
-            foreach ($tokens as $index => $token) {
-                // The namespace is a `T_NAME_QUALIFIED` that is immediately preceded by a `T_NAMESPACE`.
-                if (
-                    $token[0] === T_NAMESPACE && isset($tokens[$index + 1])
-                    && $tokens[$index + 1][0] === T_NAME_QUALIFIED
-                ) {
-                    $namespace = $tokens[$index + 1][1];
-                    continue;
-                }
-
-                // The class name is a `T_STRING` which makes it unreliable to match against, so check if we have a
-                // `T_ENUM` token with a `T_STRING` token ahead of it.
-                if ($token[0] === T_ENUM && isset($tokens[$index + 1]) && $tokens[$index + 1][0] === T_STRING) {
-                    $class = $tokens[$index + 1][1];
-                }
+        foreach ($tokens as $index => $token) {
+            // The namespace is a `T_NAME_QUALIFIED` that is immediately preceded by a `T_NAMESPACE`.
+            if (
+                $token[0] === T_NAMESPACE && isset($tokens[$index + 1])
+                && $tokens[$index + 1][0] === T_NAME_QUALIFIED
+            ) {
+                $namespace = $tokens[$index + 1][1];
             }
 
+            // The class name is a `T_STRING` which makes it unreliable to match against, so check if we have a
+            // `T_ENUM` token with a `T_STRING` token ahead of it.
+            if ($token[0] === T_ENUM && isset($tokens[$index + 1]) && $tokens[$index + 1][0] === T_STRING) {
+                $class = $tokens[$index + 1][1];
+            }
             if ($namespace && $class) {
-                // We've found both the namespace and the class, we can now stop reading and parsing the file.
                 break;
             }
         }
 
-        fclose($handle);
         return $namespace . '\\' . $class;
     }
 

--- a/tests/Commands/FqcnFromPathTest.php
+++ b/tests/Commands/FqcnFromPathTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SynergiTech\MagicEnums\Tests\Commands;
+
+use Illuminate\Filesystem\Filesystem;
+use ReflectionMethod;
+use SynergiTech\MagicEnums\Commands\GenerateCommand;
+use SynergiTech\MagicEnums\Tests\TestCase;
+
+class FqcnFromPathTest extends TestCase
+{
+    private GenerateCommand $command;
+
+    private ReflectionMethod $method;
+
+    /** @var string[] */
+    private array $tempFiles = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->command = new GenerateCommand(new Filesystem());
+        $this->method = new ReflectionMethod(GenerateCommand::class, 'fqcnFromPath');
+        $this->method->setAccessible(true);
+    }
+
+    public function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testBasicEnumParsing(): void
+    {
+        $path = $this->createTempEnum(<<<'PHP'
+<?php
+
+namespace App\Enums;
+
+enum TestEnum: string
+{
+    case First = 'first';
+    case Second = 'second';
+}
+PHP);
+
+        $result = $this->method->invoke($this->command, $path);
+
+        $this->assertSame('App\Enums\TestEnum', $result);
+    }
+
+    public function testEnumNameAtTokenBoundaryIsParsedCorrectly(): void
+    {
+        // Build a file where "enum TestEnum" straddles the old 512-byte buffer boundary.
+        // The old implementation read 512 bytes at a time and tokenized each chunk,
+        // which would split "TestEnum" into "TestE" + "num" (or similar) causing a parse failure.
+        $header = "<?php\n\nnamespace App\\Enums;\n\n";
+        $enumDeclaration = "enum TestEnum: string\n{\n    case First = 'first';\n}\n";
+
+        // Pad with a PHP comment so that "enum TestEnum" starts just before byte 512,
+        // placing the enum name itself across the boundary.
+        $targetOffset = 503; // "enum " is 5 bytes, so "TestEnum" starts at 512
+        $paddingNeeded = $targetOffset - strlen($header);
+        $comment = '// ' . str_repeat('x', $paddingNeeded - 4) . "\n"; // -4 for "// " and "\n"
+
+        $content = $header . $comment . $enumDeclaration;
+
+        // Verify our padding puts "TestEnum" right at byte 512.
+        $enumNamePos = strpos($content, 'TestEnum');
+        $this->assertSame(508, $enumNamePos, sprintf(
+            'Expected (Test)Enum at byte 512, but found it at byte %d. Adjust padding.',
+            $enumNamePos
+        ));
+
+        $path = $this->createTempEnum($content);
+        $result = $this->method->invoke($this->command, $path);
+
+        $this->assertSame('App\Enums\TestEnum', $result);
+    }
+
+    private function createTempEnum(string $content): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'enum_test_') . '.php';
+        file_put_contents($path, $content);
+        $this->tempFiles[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
The bufffer was splitting the file in the middle of the enum name, causing us to return the incorrect enum class.

I suspect removing the buffer should be fine here, enums are generally not huge file...  Could have a fair few tokens though I guess :/ 